### PR TITLE
feat/16-env.example-baselineCI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
         run: yarn install --immutable
 
       - name: Prepare api .env from example
-        # `yarn workspace api check` runs tsc, which transitively imports the
-        # Prisma client. Copy the example so anything that reads DATABASE_URL at
-        # type-check time has something to find.
         run: cp apps/api/.env.example apps/api/.env
+
+      - name: Generate Prisma client
+        run: yarn workspace api db.generate
 
       - name: Lint
         run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  lint-format-typecheck:
+    name: Lint, format, type check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Prepare api .env from example
+        # `yarn workspace api check` runs tsc, which transitively imports the
+        # Prisma client. Copy the example so anything that reads DATABASE_URL at
+        # type-check time has something to find.
+        run: cp apps/api/.env.example apps/api/.env
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Format check
+        run: yarn format:check
+
+      - name: API type check
+        run: yarn workspace api check

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,11 +1,31 @@
-# Database Configuration (used by docker-compose.yml)
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-POSTGRES_DB=se_project
-
-# Prisma Configuration
-DATABASE_URL=postgresql://postgres:postgres@localhost:5433/se_project
+# Database Configuration (Supabase)
+# Get the connection string from: Supabase Dashboard -> Project Settings -> Database -> Connection string
+# Use the "Direct connection" string for migrations and the "Transaction pooler" (port 6543) for app runtime.
+DATABASE_URL=postgresql://postgres:YOUR_SUPABASE_PASSWORD@db.YOUR_PROJECT_REF.supabase.co:5432/postgres
 
 # Server Configuration
 PORT=4000
 CORS_ORIGIN=http://localhost:3000
+
+# Google Cloud Platform (project that owns the service account and Cloud Storage bucket)
+GOOGLE_CLOUD_PROJECT_ID=your-gcp-project-id
+
+# Cloud Storage bucket used for uploads/assets
+GOOGLE_STORAGE_BUCKET=your-bucket-name
+
+# Google Service Account credentials
+# Option A (recommended for local dev): provide a path to the JSON key file.
+#   - Place google-meet.json and google-storage.json somewhere outside the repo
+#     (e.g. ~/.config/gcp/) and point GOOGLE_APPLICATION_CREDENTIALS at the one
+#     to use for the current process. Keep them out of git.
+# Option B (recommended for production / CI): paste the raw JSON content as a
+#   single-line string. Set GOOGLE_SERVICE_ACCOUNT_KEY to the full JSON and
+#   GOOGLE_SERVICE_ACCOUNT_KEY_FILE to whichever you need (meet vs storage).
+GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/google-storage.json
+GOOGLE_MEET_CREDENTIALS_PATH=/absolute/path/to/google-meet.json
+GOOGLE_STORAGE_CREDENTIALS_PATH=/absolute/path/to/google-storage.json
+
+# If you prefer to ship the JSON inline (useful for CI secrets), paste the
+# entire contents of google-meet.json / google-storage.json as a single line:
+# GOOGLE_MEET_SERVICE_ACCOUNT_KEY={"type":"service_account",...}
+# GOOGLE_STORAGE_SERVICE_ACCOUNT_KEY={"type":"service_account",...}

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,1 +1,11 @@
+# Backend API
 NEXT_PUBLIC_API_URL=http://localhost:4000/api
+
+# Supabase (client-side, only if you wire up the Supabase JS SDK in the web app).
+# The anon key is safe to expose; the service role key is NOT and must stay on the API.
+NEXT_PUBLIC_SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+
+# Google APIs that the browser calls directly (only add these if you need to call
+# Google from the client; otherwise the API proxies them and these stay unset).
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-oauth-client-id.apps.googleusercontent.com


### PR DESCRIPTION
## User Story ID
US0-3

## Description
The env.templates are written.
- For Supabase, the credentials can be accessed in "Connect" section in the dashboard.
- For Google Service Account credentials, the JSON secret can be either set at path/to/secret.json (if on local environment) or pasted as an actual string (if on production enviroment). 

Also, I have created `ci.yml` to pre-check PR requests as told in the description.

## Checklist

- [X] I have self-reviewed my code and works locally
- [X] I have tagged a reviewer for this PR
- [X] I have assigned myself as a assignee for this PR
- [X] I have linked the related issue(s) to this PR
- [X] `yarn lint` passes locally <- there is warning, but it is not in my scope of this PR

## Screenshot(s)
- 

## Remark
- Some of the environments might not be used, but I have put it at first for reference for future sprint sessions.
- Vercel has a CI check available for both api/ and web/, and it is already implemented.