### PR TITLE
Feat/25 login page UI

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { LoginPanel } from "@/components/auth/login-panel";
+
+export const metadata: Metadata = {
+  title: "Log in | Tutorist",
+  description: "Log in to your Tutorist account.",
+};
+
+export default function LoginPage() {
+  return (
+    <main className="flex min-h-[70vh] items-center justify-center px-base py-3xl">
+      <LoginPanel />
+    </main>
+  );
+}

--- a/apps/web/src/components/auth/login-form.stories.tsx
+++ b/apps/web/src/components/auth/login-form.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { LoginForm } from "./login-form";
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const meta = {
+  title: "Auth/LoginForm",
+  component: LoginForm,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Login form for the email/password flow. Field errors are validated on submit; " +
+          "credential failures surface as a single form-level message so the UI never " +
+          "reveals whether the email or the password was wrong. Press **Log in** in each " +
+          "story to see the state it demonstrates.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  args: {
+    onSubmit: async () => delay(600),
+  },
+} satisfies Meta<typeof LoginForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Happy path — resolves after a short delay, as a successful login would. */
+export const Default: Story = {};
+
+/** Submit with both fields empty to see the per-field required messages. */
+export const ValidationErrors: Story = {};
+
+/** Submit anything to see the loading state; the promise never settles. */
+export const Submitting: Story = {
+  args: {
+    onSubmit: () => new Promise<void>(() => {}),
+  },
+};
+
+/**
+ * What a 401 looks like. The API answers a wrong password and an unknown email
+ * with this same message, so the form cannot distinguish the two either.
+ */
+export const InvalidCredentials: Story = {
+  args: {
+    onSubmit: async () => {
+      await delay(600);
+      throw new Error("Invalid email or password");
+    },
+  },
+};
+
+/** A fetch-level failure (API down, no network) rather than a rejected login. */
+export const ServerUnreachable: Story = {
+  args: {
+    onSubmit: async () => {
+      await delay(600);
+      throw new TypeError("Failed to fetch");
+    },
+  },
+};

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { PasswordForm } from "@/components/ui/password-form";
+import { cn } from "@/lib/utils";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const FALLBACK_ERROR = "Unable to log in. Please try again.";
+const NETWORK_ERROR = "Unable to reach the server. Please try again.";
+
+export interface LoginFormValues {
+  email: string;
+  password: string;
+}
+
+export interface LoginFormProps {
+  /**
+   * Performs the login. Rejecting marks the attempt as failed and surfaces the
+   * rejection's message as the form-level error, so the caller owns the API
+   * call and the post-login redirect while this component owns the UI state.
+   */
+  onSubmit: (values: LoginFormValues) => Promise<void>;
+  className?: string;
+}
+
+type FieldErrors = Partial<Record<keyof LoginFormValues, string>>;
+
+function validate({ email, password }: LoginFormValues): FieldErrors {
+  const errors: FieldErrors = {};
+  if (!email) {
+    errors.email = "Email is required";
+  } else if (!EMAIL_PATTERN.test(email)) {
+    errors.email = "Please enter a valid email address";
+  }
+  if (!password) {
+    errors.password = "Password is required";
+  }
+  return errors;
+}
+
+export function LoginForm({ onSubmit, className }: LoginFormProps) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const values = { email: email.trim(), password };
+    const errors = validate(values);
+    setFieldErrors(errors);
+    setFormError(null);
+    if (Object.keys(errors).length > 0) return;
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit(values);
+    } catch (error) {
+      // The API answers a bad email and a bad password with the same 401 body,
+      // so echoing its message keeps that ambiguity intact. Field-level errors
+      // stay cleared here — highlighting one field would reveal which was wrong.
+      if (error instanceof TypeError) {
+        setFormError(NETWORK_ERROR);
+      } else {
+        setFormError(error instanceof Error && error.message ? error.message : FALLBACK_ERROR);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form
+      noValidate
+      onSubmit={handleSubmit}
+      className={cn("flex w-full max-w-[400px] flex-col gap-base", className)}
+    >
+      <div className="flex flex-col gap-xs">
+        <h1 className="font-inter text-heading-md text-ink-black">Log in</h1>
+        <p className="font-inter text-caption text-ink">
+          Enter your details to access your account.
+        </p>
+      </div>
+
+      <Input
+        label="Email"
+        type="email"
+        inputMode="email"
+        autoComplete="email"
+        placeholder="Enter your email"
+        value={email}
+        onChange={(event) => setEmail(event.target.value)}
+        disabled={isSubmitting}
+        error={Boolean(fieldErrors.email)}
+        errorMessage={fieldErrors.email}
+      />
+
+      <PasswordForm
+        label="Password"
+        autoComplete="current-password"
+        value={password}
+        onChange={(event) => setPassword(event.target.value)}
+        disabled={isSubmitting}
+        error={Boolean(fieldErrors.password)}
+        errorMessage={fieldErrors.password}
+      />
+
+      {formError && (
+        <p role="alert" className="font-inter text-error text-xs leading-[23px] sm:text-sm">
+          {formError}
+        </p>
+      )}
+
+      <Button type="submit" isLoading={isSubmitting} className="w-full">
+        Log in
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/components/auth/login-panel.tsx
+++ b/apps/web/src/components/auth/login-panel.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { LoginForm, type LoginFormValues } from "@/components/auth/login-form";
+import { apiClient } from "@/lib/api-client";
+import { saveSession } from "@/lib/auth-storage";
+import type { LoginResponse } from "@/types/auth";
+
+export interface LoginPanelProps {
+  /** Where to send the user once the token is stored. */
+  redirectTo?: string;
+}
+
+/**
+ * Wires the presentational LoginForm to the API and the router. Kept separate
+ * so the page itself stays a server component and can export metadata.
+ */
+export function LoginPanel({ redirectTo = "/" }: LoginPanelProps) {
+  const router = useRouter();
+
+  async function handleLogin(values: LoginFormValues) {
+    const session = await apiClient.post<LoginResponse>("/auth/login", values);
+    saveSession(session);
+    // replace, not push: the back button should not return to the login form
+    // once a session exists.
+    router.replace(redirectTo);
+    router.refresh();
+  }
+
+  return <LoginForm onSubmit={handleLogin} />;
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,12 +1,21 @@
+import { getToken } from "@/lib/auth-storage";
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000/api";
 
 type ApiResponse<T> =
   { success: true; message: string; data: T } | { success: false; message: string };
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  // Null during SSR and before login; the header is omitted in both cases.
+  const token = getToken();
+
   const res = await fetch(`${API_URL}${path}`, {
     ...init,
-    headers: { "Content-Type": "application/json", ...init?.headers },
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...init?.headers,
+    },
   });
   const body: ApiResponse<T> = await res.json();
 

--- a/apps/web/src/lib/auth-storage.ts
+++ b/apps/web/src/lib/auth-storage.ts
@@ -1,0 +1,56 @@
+import type { LoginResponse } from "@/types/auth";
+
+const TOKEN_KEY = "tutorist.auth.token";
+const USER_KEY = "tutorist.auth.user";
+
+type AuthUser = LoginResponse["user"];
+
+/**
+ * Session lives in localStorage because the API returns the token in the
+ * response body rather than an httpOnly cookie. Every access is guarded:
+ * this module is imported by code that also runs during SSR, and browsers
+ * in private mode can throw on access rather than returning null.
+ */
+function readItem(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function saveSession({ token, user }: LoginResponse): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(TOKEN_KEY, token);
+    window.localStorage.setItem(USER_KEY, JSON.stringify(user));
+  } catch {
+    // Storage unavailable (private mode, quota). The token stays in memory
+    // for this page load only — the user simply has to log in again later.
+  }
+}
+
+export function getToken(): string | null {
+  return readItem(TOKEN_KEY);
+}
+
+export function getUser(): AuthUser | null {
+  const raw = readItem(USER_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as AuthUser;
+  } catch {
+    return null;
+  }
+}
+
+export function clearSession(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(TOKEN_KEY);
+    window.localStorage.removeItem(USER_KEY);
+  } catch {
+    // Nothing to clean up if storage is unavailable.
+  }
+}

--- a/apps/web/src/types/auth.ts
+++ b/apps/web/src/types/auth.ts
@@ -1,0 +1,12 @@
+export type UserRole = "student" | "tutor";
+
+export type LoginResponse = {
+  token: string;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    role: UserRole;
+    profileUrl: string;
+  };
+};


### PR DESCRIPTION
## User Story ID
US1-2
## Description
Adds the login page UI at `/login`, built from the existing `Input`,
`PasswordForm`, and `Button` components per `DESIGN.md`.

- `login-form.tsx` — form with validation, loading, and error states
- `login-panel.tsx` — calls the API, saves the session, redirects
- `app/login/page.tsx` — the route
- `lib/auth-storage.ts` — stores the token in `localStorage`
- `lib/api-client.ts` — sends `Authorization: Bearer <token>`

## Checklist
- [x] I have self-reviewed my code and works locally
- [x] I have tagged a reviewer for this PR
- [x] I have assigned myself as a assignee for this PR
- [x] I have linked the related issue(s) to this PR
- [x] `yarn lint` passes locally

## Screenshot(s)
<img width="2880" height="1562" alt="image" src="https://github.com/user-attachments/assets/6bba53a6-2280-459b-a458-f10d80e406e5" />

## Remark
