### PR TITLE
Feat/33 add logout api endpoint

### DIFF
--- a/apps/api/src/controller/auth.controller.ts
+++ b/apps/api/src/controller/auth.controller.ts
@@ -44,4 +44,12 @@ export const authController = {
       next(error);
     }
   },
+  async logout(_req: Request, res: Response, next: NextFunction) {
+    try {
+      await authService.logout();
+      res.status(200).json(successResponse(null, "Logout successful"));
+    } catch (error) {
+      next(error);
+    }
+  },
 };

--- a/apps/api/src/router/auth.router.ts
+++ b/apps/api/src/router/auth.router.ts
@@ -70,3 +70,26 @@ authRouter.post("/register", authController.register);
  *       401: { description: Invalid email or password }
  */
 authRouter.post("/login", authController.login);
+/**
+ * @openapi
+ * /auth/logout:
+ *   post:
+ *     summary: Log out the current user
+ *     tags: [Authentication]
+ *     description: >
+ *       Stateless logout. The JWT is not stored server-side, so the client ends
+ *       the session by discarding its token. This endpoint always succeeds — even
+ *       without an active session — and is safe to call repeatedly.
+ *     responses:
+ *       200:
+ *         description: Logout successful
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean, example: true }
+ *                 message: { type: string, example: Logout successful }
+ *                 data: { type: object, nullable: true, example: null }
+ */
+authRouter.post("/logout", authController.logout);

--- a/apps/api/src/routes.ts
+++ b/apps/api/src/routes.ts
@@ -8,4 +8,3 @@ export const apiRoutes = Router();
 apiRoutes.use("/auth", authRouter);
 apiRoutes.use("/subjects", subjectRouter);
 apiRoutes.use("/users", userRouter);
-apiRoutes.use("/auth", authRouter);

--- a/apps/api/src/service/auth.service.ts
+++ b/apps/api/src/service/auth.service.ts
@@ -66,4 +66,10 @@ export const authService = {
       },
     };
   },
+  async logout() {
+    // Auth is stateless: the JWT is not persisted server-side, so there is
+    // nothing to invalidate here — the client ends the session by discarding
+    // its token. This method exists so logout is an explicit, idempotent step
+    // and gives us one place to add token revocation later if that's needed.
+  },
 };


### PR DESCRIPTION
## User Story ID
add logout api endpoint 

## Description
Add logout API endpoint (#33)

Adds POST /api/auth/logout following the existing router → controller → service convention.

Since auth is stateless JWT (no server-side session store), logout is a stateless acknowledgement: the endpoint always returns 200 { success, message, data: null } and is idempotent — safe to call with or without an active session. Real session-end is the client discarding its token. Left a comment marking the service method as the single place to add token revocation later if needed.

Also removes a duplicate authRouter registration in routes.ts.
## Checklist

- [x] I have self-reviewed my code and works locally
- [x] I have tagged a reviewer for this PR
- [x] I have assigned myself as a assignee for this PR
- [ ] I have linked the related issue(s) to this PR
- [ ] `yarn lint` passes locally

## Screenshot(s)
<img width="1147" height="512" alt="image_2026-09-06_225419009" src="https://github.com/user-attachments/assets/b38a1a08-7b16-49df-83d1-e258b41fb2dd" />

## Remark
