### PR TITLE
feat: add api for user to update profile

### DIFF
--- a/apps/api/src/controller/user.controller.ts
+++ b/apps/api/src/controller/user.controller.ts
@@ -28,10 +28,17 @@ const editableProfileFields = {
 } as const;
 
 const studentProfileUpdateSchema = z
-  .object({ ...editableProfileFields, ...studentProfileFields })
+  .object({
+    ...editableProfileFields,
+    gradeLevel: studentProfileFields.gradeLevel.optional(),
+    goals: studentProfileFields.goals.optional(),
+  })
   .strict();
 const tutorProfileUpdateSchema = z
-  .object({ ...editableProfileFields, ...tutorProfileFields })
+  .object({
+    ...editableProfileFields,
+    hourlyRate: tutorProfileFields.hourlyRate.optional(),
+  })
   .strict();
 
 type ProfileData = z.infer<typeof studentProfileSchema> | z.infer<typeof tutorProfileSchema>;

--- a/apps/api/src/controller/user.controller.ts
+++ b/apps/api/src/controller/user.controller.ts
@@ -6,16 +6,37 @@ import type { AuthRequest } from "../common/middleware/auth.middleware.js";
 import { Role } from "@prisma/client";
 import { BadRequestError, UnauthorizedError } from "../common/errors/app-error.js";
 
-const studentProfileSchema = z.object({
+const studentProfileFields = {
   gradeLevel: z.string().trim().min(1, "Grade level is required"),
   goals: z.string().trim().min(1, "Goals are required"),
-});
+} as const;
 
-const tutorProfileSchema = z.object({
-  hourlyRate: z.number().positive("Hourly rate must be positive"),
-});
+const tutorProfileFields = {
+  hourlyRate: z
+    .number()
+    .finite("Hourly rate must be finite")
+    .positive("Hourly rate must be positive"),
+} as const;
+
+const studentProfileSchema = z.object(studentProfileFields).strict();
+const tutorProfileSchema = z.object(tutorProfileFields).strict();
+
+const editableProfileFields = {
+  name: z.string().trim().min(1, "Name is required").max(100, "Name is too long"),
+  profileUrl: z.string().trim().url("Please enter a valid profile image URL"),
+  bio: z.string().trim().max(1000, "Bio must be at most 1000 characters").nullable(),
+} as const;
+
+const studentProfileUpdateSchema = z
+  .object({ ...editableProfileFields, ...studentProfileFields })
+  .strict();
+const tutorProfileUpdateSchema = z
+  .object({ ...editableProfileFields, ...tutorProfileFields })
+  .strict();
 
 type ProfileData = z.infer<typeof studentProfileSchema> | z.infer<typeof tutorProfileSchema>;
+type ProfileUpdateData =
+  z.infer<typeof studentProfileUpdateSchema> | z.infer<typeof tutorProfileUpdateSchema>;
 
 export const userController = {
   async submitProfile(req: AuthRequest, res: Response, next: NextFunction) {
@@ -38,6 +59,33 @@ export const userController = {
 
       const updatedUser = await userService.completeProfile(user.id, role, validatedData);
       res.status(200).json(successResponse(updatedUser, "Profile completed successfully"));
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async updateProfile(req: AuthRequest, res: Response, next: NextFunction) {
+    try {
+      const user = req.user;
+      if (!user) {
+        throw new UnauthorizedError("User not found in request");
+      }
+
+      let role: Role;
+      let validatedData: ProfileUpdateData;
+
+      if (user.role === Role.student) {
+        role = Role.student;
+        validatedData = studentProfileUpdateSchema.parse(req.body);
+      } else if (user.role === Role.tutor) {
+        role = Role.tutor;
+        validatedData = tutorProfileUpdateSchema.parse(req.body);
+      } else {
+        throw new UnauthorizedError("Invalid authentication role");
+      }
+
+      const updatedUser = await userService.updateProfile(user.id, role, validatedData);
+      res.status(200).json(successResponse(updatedUser, "Profile updated successfully"));
     } catch (error) {
       next(error);
     }

--- a/apps/api/src/repository/user.repository.ts
+++ b/apps/api/src/repository/user.repository.ts
@@ -37,14 +37,13 @@ export type ProfileOwner = Pick<User, "id" | "role" | "profileComplete">;
 type CommonProfileUpdate = Pick<User, "name" | "profileUrl" | "bio">;
 
 export type ExistingProfileUpdate =
-  | (CommonProfileUpdate &
-      Pick<User, "gradeLevel" | "goals"> & {
-        gradeLevel: string;
-        goals: string;
-        hourlyRate?: never;
-      })
   | (CommonProfileUpdate & {
-      hourlyRate: Prisma.Decimal;
+      gradeLevel?: string;
+      goals?: string;
+      hourlyRate?: never;
+    })
+  | (CommonProfileUpdate & {
+      hourlyRate?: Prisma.Decimal;
       gradeLevel?: never;
       goals?: never;
     });

--- a/apps/api/src/repository/user.repository.ts
+++ b/apps/api/src/repository/user.repository.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../config/prisma.js";
-import type { User } from "@prisma/client";
+import type { Prisma, User } from "@prisma/client";
 
 const publicUserSelect = {
   id: true,
@@ -18,8 +18,44 @@ const publicUserSelect = {
 
 export type PublicUser = Omit<User, "passwordHash">;
 
+export type ProfileOwner = Pick<User, "id" | "role" | "profileComplete">;
+
+type CommonProfileUpdate = Pick<User, "name" | "profileUrl" | "bio">;
+
+export type ExistingProfileUpdate =
+  | (CommonProfileUpdate &
+      Pick<User, "gradeLevel" | "goals"> & {
+        gradeLevel: string;
+        goals: string;
+        hourlyRate?: never;
+      })
+  | (CommonProfileUpdate & {
+      hourlyRate: Prisma.Decimal;
+      gradeLevel?: never;
+      goals?: never;
+    });
+
 export const userRepository = {
   async updateProfile(userId: string, data: Partial<User>): Promise<PublicUser> {
+    return prisma.user.update({
+      where: { id: userId },
+      data,
+      select: publicUserSelect,
+    });
+  },
+
+  async findProfileOwnerById(userId: string): Promise<ProfileOwner | null> {
+    return prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        role: true,
+        profileComplete: true,
+      },
+    });
+  },
+
+  async updateExistingProfile(userId: string, data: ExistingProfileUpdate): Promise<PublicUser> {
     return prisma.user.update({
       where: { id: userId },
       data,

--- a/apps/api/src/router/user.router.ts
+++ b/apps/api/src/router/user.router.ts
@@ -61,7 +61,7 @@ import type { AuthRequest } from "../common/middleware/auth.middleware.js";
  *     StudentProfileUpdate:
  *       type: object
  *       additionalProperties: false
- *       required: [name, profileUrl, bio, gradeLevel, goals]
+ *       required: [name, profileUrl, bio]
  *       properties:
  *         name:
  *           type: string
@@ -80,15 +80,17 @@ import type { AuthRequest } from "../common/middleware/auth.middleware.js";
  *         gradeLevel:
  *           type: string
  *           minLength: 1
+ *           description: Optional; retains its current value when omitted
  *           example: "Grade 10"
  *         goals:
  *           type: string
  *           minLength: 1
+ *           description: Optional; retains its current value when omitted
  *           example: "Prepare for my final examination."
  *     TutorProfileUpdate:
  *       type: object
  *       additionalProperties: false
- *       required: [name, profileUrl, bio, hourlyRate]
+ *       required: [name, profileUrl, bio]
  *       properties:
  *         name:
  *           type: string
@@ -107,6 +109,7 @@ import type { AuthRequest } from "../common/middleware/auth.middleware.js";
  *         hourlyRate:
  *           type: number
  *           exclusiveMinimum: 0
+ *           description: Optional; retains its current value when omitted
  *           example: 750.0
  */
 
@@ -170,7 +173,7 @@ router.get("/me", authMiddleware, userController.getProfile);
  * /users/profile:
  *   put:
  *     summary: Replace the authenticated user's editable profile
- *     description: Updates all editable profile fields for the authenticated role. Email, password, and role cannot be changed through this endpoint.
+ *     description: Updates the common profile fields and any supplied role-specific fields. Omitted role-specific fields retain their current values. Email, password, and role cannot be changed through this endpoint.
  *     tags: [User]
  *     security:
  *       - bearerAuth: []
@@ -179,7 +182,7 @@ router.get("/me", authMiddleware, userController.getProfile);
  *       content:
  *         application/json:
  *           schema:
- *             oneOf:
+ *             anyOf:
  *               - $ref: '#/components/schemas/StudentProfileUpdate'
  *               - $ref: '#/components/schemas/TutorProfileUpdate'
  *     responses:

--- a/apps/api/src/router/user.router.ts
+++ b/apps/api/src/router/user.router.ts
@@ -14,6 +14,7 @@ import type { AuthRequest } from "../common/middleware/auth.middleware.js";
  *   schemas:
  *     StudentProfile:
  *       type: object
+ *       additionalProperties: false
  *       required: [gradeLevel, goals]
  *       properties:
  *         gradeLevel:
@@ -24,11 +25,63 @@ import type { AuthRequest } from "../common/middleware/auth.middleware.js";
  *           example: "Improve my math skills"
  *     TutorProfile:
  *       type: object
+ *       additionalProperties: false
  *       required: [hourlyRate]
  *       properties:
  *         hourlyRate:
  *           type: number
+ *           exclusiveMinimum: 0
  *           example: 25.0
+ *     StudentProfileUpdate:
+ *       type: object
+ *       additionalProperties: false
+ *       required: [name, profileUrl, bio, gradeLevel, goals]
+ *       properties:
+ *         name:
+ *           type: string
+ *           minLength: 1
+ *           maxLength: 100
+ *           example: "Student Name"
+ *         profileUrl:
+ *           type: string
+ *           format: uri
+ *           example: "https://cdn.example.com/student.jpg"
+ *         bio:
+ *           type: string
+ *           nullable: true
+ *           maxLength: 1000
+ *           example: "I enjoy mathematics."
+ *         gradeLevel:
+ *           type: string
+ *           minLength: 1
+ *           example: "Grade 10"
+ *         goals:
+ *           type: string
+ *           minLength: 1
+ *           example: "Prepare for my final examination."
+ *     TutorProfileUpdate:
+ *       type: object
+ *       additionalProperties: false
+ *       required: [name, profileUrl, bio, hourlyRate]
+ *       properties:
+ *         name:
+ *           type: string
+ *           minLength: 1
+ *           maxLength: 100
+ *           example: "Tutor Name"
+ *         profileUrl:
+ *           type: string
+ *           format: uri
+ *           example: "https://cdn.example.com/tutor.jpg"
+ *         bio:
+ *           type: string
+ *           nullable: true
+ *           maxLength: 1000
+ *           example: "I have five years of teaching experience."
+ *         hourlyRate:
+ *           type: number
+ *           exclusiveMinimum: 0
+ *           example: 750.0
  */
 
 // Cast router to use AuthRequest
@@ -60,5 +113,31 @@ router.use((req, res, next) => {
  *       401: { description: Unauthorized }
  */
 router.post("/profile", authMiddleware, userController.submitProfile);
+
+/**
+ * @swagger
+ * /users/profile:
+ *   put:
+ *     summary: Replace the authenticated user's editable profile
+ *     description: Updates all editable profile fields for the authenticated role. Email, password, and role cannot be changed through this endpoint.
+ *     tags: [User]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             oneOf:
+ *               - $ref: '#/components/schemas/StudentProfileUpdate'
+ *               - $ref: '#/components/schemas/TutorProfileUpdate'
+ *     responses:
+ *       200: { description: Profile updated successfully }
+ *       400: { description: Missing, invalid, role-incompatible, or unknown request fields }
+ *       401: { description: Missing or invalid authentication, deleted user, or role mismatch }
+ *       409: { description: Initial profile completion is required }
+ *       500: { description: Internal server error }
+ */
+router.put("/profile", authMiddleware, userController.updateProfile);
 
 export const userRouter = router;

--- a/apps/api/src/service/user.service.ts
+++ b/apps/api/src/service/user.service.ts
@@ -1,6 +1,11 @@
 import { Role, User, Prisma } from "@prisma/client";
 import { userRepository } from "../repository/user.repository.js";
-import { NotFoundError, BadRequestError, ConflictError, UnauthorizedError } from "../common/errors/app-error.js";
+import {
+  NotFoundError,
+  BadRequestError,
+  ConflictError,
+  UnauthorizedError,
+} from "../common/errors/app-error.js";
 
 type ProfileData = {
   gradeLevel?: string;
@@ -80,21 +85,17 @@ export const userService = {
 
     let updateData;
     if (role === Role.student) {
-      if (!data.gradeLevel || !data.goals) {
-        throw new BadRequestError("Grade level and goals are required for students");
-      }
       updateData = {
         ...commonData,
-        gradeLevel: data.gradeLevel,
-        goals: data.goals,
+        ...(data.gradeLevel !== undefined && { gradeLevel: data.gradeLevel }),
+        ...(data.goals !== undefined && { goals: data.goals }),
       };
     } else if (role === Role.tutor) {
-      if (data.hourlyRate === undefined) {
-        throw new BadRequestError("Hourly rate is required for tutors");
-      }
       updateData = {
         ...commonData,
-        hourlyRate: new Prisma.Decimal(data.hourlyRate),
+        ...(data.hourlyRate !== undefined && {
+          hourlyRate: new Prisma.Decimal(data.hourlyRate),
+        }),
       };
     } else {
       throw new UnauthorizedError("Invalid authentication role");

--- a/apps/api/src/service/user.service.ts
+++ b/apps/api/src/service/user.service.ts
@@ -1,11 +1,17 @@
 import { Role, User, Prisma } from "@prisma/client";
 import { userRepository } from "../repository/user.repository.js";
-import { BadRequestError } from "../common/errors/app-error.js";
+import { BadRequestError, ConflictError, UnauthorizedError } from "../common/errors/app-error.js";
 
 type ProfileData = {
   gradeLevel?: string;
   goals?: string;
   hourlyRate?: number;
+};
+
+type ProfileUpdateData = ProfileData & {
+  name: string;
+  profileUrl: string;
+  bio: string | null;
 };
 
 export const userService = {
@@ -27,5 +33,58 @@ export const userService = {
     }
 
     return userRepository.updateProfile(userId, updateData);
+  },
+
+  async updateProfile(userId: string, role: Role, data: ProfileUpdateData) {
+    const profileOwner = await userRepository.findProfileOwnerById(userId);
+
+    if (!profileOwner) {
+      throw new UnauthorizedError("Authenticated user no longer exists");
+    }
+
+    if (profileOwner.role !== role) {
+      throw new UnauthorizedError("Authentication role does not match the user account");
+    }
+
+    if (!profileOwner.profileComplete) {
+      throw new ConflictError("Initial profile completion is required before updating the profile");
+    }
+
+    const commonData = {
+      name: data.name,
+      profileUrl: data.profileUrl,
+      bio: data.bio,
+    };
+
+    let updateData;
+    if (role === Role.student) {
+      if (!data.gradeLevel || !data.goals) {
+        throw new BadRequestError("Grade level and goals are required for students");
+      }
+      updateData = {
+        ...commonData,
+        gradeLevel: data.gradeLevel,
+        goals: data.goals,
+      };
+    } else if (role === Role.tutor) {
+      if (data.hourlyRate === undefined) {
+        throw new BadRequestError("Hourly rate is required for tutors");
+      }
+      updateData = {
+        ...commonData,
+        hourlyRate: new Prisma.Decimal(data.hourlyRate),
+      };
+    } else {
+      throw new UnauthorizedError("Invalid authentication role");
+    }
+
+    try {
+      return await userRepository.updateExistingProfile(userId, updateData);
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025") {
+        throw new UnauthorizedError("Authenticated user no longer exists");
+      }
+      throw error;
+    }
   },
 };

--- a/apps/web/src/components/auth/registration-form.tsx
+++ b/apps/web/src/components/auth/registration-form.tsx
@@ -76,7 +76,7 @@ export function RegistrationForm({
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    
+
     const values = { role, email: email.trim(), password, confirmPassword };
     const errors = validate(values);
     setFieldErrors(errors);

--- a/apps/web/src/components/auth/registration-form.tsx
+++ b/apps/web/src/components/auth/registration-form.tsx
@@ -76,7 +76,7 @@ export function RegistrationForm({
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-
+    
     const values = { role, email: email.trim(), password, confirmPassword };
     const errors = validate(values);
     setFieldErrors(errors);


### PR DESCRIPTION
## User Story ID

US2-2

## Description

- Backend
  - Implemented authenticated profile updates via `PUT /api/users/profile`.
  - Added role-specific validation for student and tutor profiles.
  - Prevented updates to restricted fields such as email, password, role, wallet balance, and profile completion status.
  - Verified the authenticated user and role against the database before updating.
  - Added Swagger documentation for both student and tutor request bodies.
  - Ensured responses exclude password hashes.

## Checklist

- [x] I have self-reviewed my code and it works locally
- [x] I have tagged a reviewer for this PR
- [x] I have assigned myself as an assignee for this PR
- [x] I have linked the related issue(s) to this PR
- [x] API type checking passes locally
- [x] Scoped lint and formatting checks pass locally

## Screenshot(s)

- API endpoint

when profile initiation is incomplete:
<img width="1765" height="482" alt="image" src="https://github.com/user-attachments/assets/5a304d4c-3e91-4f1c-9385-d63d626f2f35" />

when profile initiation is complete (student):
<img width="1777" height="617" alt="image" src="https://github.com/user-attachments/assets/255e4b00-a607-4e94-8be8-8584cf87cc3e" />

when profile initiation is complete (tutor):
<img width="1777" height="600" alt="image" src="https://github.com/user-attachments/assets/493260b1-b73a-4efb-98f4-ba96c6f54e4d" />

## Remark